### PR TITLE
Update HttpKit.java

### DIFF
--- a/src/com/jfinal/kit/HttpKit.java
+++ b/src/com/jfinal/kit/HttpKit.java
@@ -148,7 +148,7 @@ public class HttpKit {
 			conn.connect();
 			
 			OutputStream out = conn.getOutputStream();
-			out.write(data.getBytes(CHARSET));
+			out.write(null==data?"".getBytes(CHARSET):data.getBytes(CHARSET));
 			out.flush();
 			out.close();
 			


### PR DESCRIPTION
解决post() data参数为null报空指针的错误