### PR TITLE
Update ActionHandler.java

### DIFF
--- a/src/com/jfinal/core/ActionHandler.java
+++ b/src/com/jfinal/core/ActionHandler.java
@@ -94,7 +94,8 @@ final class ActionHandler extends Handler {
 			
 			if (render == null)
 				render = renderFactory.getDefaultRender(action.getViewPath() + action.getMethodName());
-			render.setContext(request, response, action.getViewPath()).render();
+			if (!response.isCommitted())
+				render.setContext(request, response, action.getViewPath()).render();
 		}
 		catch (RenderException e) {
 			if (log.isErrorEnabled()) {


### PR DESCRIPTION
1.解决的问题
  a. 如果使用JFinal的开发者没有使用render, 而是直接使用类"redirect"的方式相应客户端，而这时 JFinal 会发现Controller并没有调用render，从而获取默认render，执行默认响应操作，这时会抛出异常。
  b. 在解决此问题时发现有很多人遇到这个问题，都是使用renderNull的方式作为workaround。这样不符合JFinal作为极简框架的原则。

2.解决的方案
  a. commited字段： servlet api 提供了isCommited()方法来判断响应是否已经完成，对应的web应用服务器的底层就是使用commited字段作为标志，比较准确。
  b. 在执行默认的render之前，调用isCommited()作为判断条件，即如果response已经完成，不再执行默认的render。