### PR TITLE
实现 DateKit API, 更新 PropKit

### DIFF
--- a/src/main/java/com/jfinal/ext/kit/DateKit.java
+++ b/src/main/java/com/jfinal/ext/kit/DateKit.java
@@ -16,40 +16,98 @@
 
 package com.jfinal.ext.kit;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import com.jfinal.kit.StrKit;
 
 /**
  * DateKit.
+ * Updated by Lemond on Feb 19, 2017
  */
 public class DateKit {
-	
+
 	public static String dateFormat = "yyyy-MM-dd";
 	public static String timeFormat = "yyyy-MM-dd HH:mm:ss";
-	
+
 	public static void setDateFromat(String dateFormat) {
 		if (StrKit.isBlank(dateFormat)) {
 			throw new IllegalArgumentException("dateFormat can not be blank.");
 		}
 		DateKit.dateFormat = dateFormat;
 	}
-	
+
 	public static void setTimeFromat(String timeFormat) {
 		if (StrKit.isBlank(timeFormat)) {
 			throw new IllegalArgumentException("timeFormat can not be blank.");
 		}
 		DateKit.timeFormat = timeFormat;
 	}
-	
-	public static Date toDate(String dateStr) {
-		throw new RuntimeException("Not finish!!!");
-	}
-	
-	public static String toStr(Date date) {
-		return toStr(date, DateKit.dateFormat);
-	}
-	
-	public static String toStr(Date date, String format) {
-		throw new RuntimeException("Not finish!!!");
-	}
+
+    /**
+     * 按照默认日期格式(yyyy-MM-dd)处理 dateStr 并返回{@link java.util.Date} 对象
+     */
+    public static Date toDate(String dateStr) {
+        return toDate(dateStr, DateKit.dateFormat);
+    }
+
+    /**
+     * 按照默认时间格式(yyyy-MM-dd HH:mm:ss)处理 dateStr 并返回{@link java.util.Date} 对象
+     */
+    public static Date toDateWithTime(String timeStr){
+        return toDate(timeStr, DateKit.timeFormat);
+    }
+
+    /**
+     * 按照默认/自定义格式 接受日期/时间字符串并处理为 {@link java.util.Date} 对象
+     *
+     * @param dateOrTimeStr 日期/时间字符串,支持自定义格式
+     * @param sourceFormat dateOrTimeStr 格式
+     * @return {@link java.util.Date} 对象
+     */
+    public static Date toDate(String dateOrTimeStr, String sourceFormat) {
+        if (StrKit.isBlank(dateOrTimeStr)) {
+            throw new IllegalArgumentException("dateStr can not be blank.");
+        }
+
+        if (StrKit.isBlank(sourceFormat)) {
+            throw new IllegalArgumentException("sourceFormat can not be blank.");
+        }
+
+        try {
+            SimpleDateFormat simpleDateFormat = new SimpleDateFormat(sourceFormat);
+            return simpleDateFormat.parse(dateOrTimeStr);
+        } catch (ParseException e) {
+            throw new IllegalArgumentException("date or time string not match format:" + sourceFormat);
+        }
+    }
+
+    /**
+     * 按照默认格式返回格式化后的日期字符串
+     */
+    public static String toStr(Date date) {
+        return toStr(date, DateKit.dateFormat);
+    }
+
+    /**
+     * 按照默认/自定义格式 返回格式化的日期/时间字符串
+     *
+     * @param date   {@link java.util.Date} 类实例
+     * @param format 日期/时间格式 如果留空，返回默认格式(yyyy-MM-dd)的日期字符串，传入DateKit.timeFormat 返回格式化的时间字符串
+     *               支持自定义格式
+     * @return 格式化的日期字符串
+     */
+    public static String toStr(Date date, String format) {
+        if (date == null) {
+            throw new IllegalArgumentException("date can not be blank.");
+        }
+
+        if (StrKit.isBlank(format)) {
+            return toStr(date);
+        }
+
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat(format);
+        String dateString = simpleDateFormat.format(date);
+        return dateString;
+    }
 }

--- a/src/main/java/com/jfinal/kit/Prop.java
+++ b/src/main/java/com/jfinal/kit/Prop.java
@@ -107,13 +107,15 @@ public class Prop {
 			if (inputStream != null) try {inputStream.close();} catch (IOException e) {LogKit.error(e.getMessage(), e);}
 		}
 	}
-	
+
 	public String get(String key) {
-		return properties.getProperty(key);
+		String value = properties.getProperty(key);
+		return (value == null) ? value : value.trim();
 	}
 	
 	public String get(String key, String defaultValue) {
-		return properties.getProperty(key, defaultValue);
+		String value = properties.getProperty(key, defaultValue);
+		return (value == null) ? value : value.trim();
 	}
 	
 	public Integer getInt(String key) {


### PR DESCRIPTION
抱歉不熟悉 pull request 流程 直接提交到 master 了

**对原有未实现的方法添加实现**

1. toDate(String dateOrTimeStr, String sourceFormat) 也可以处理带时间的日期，但需要 set 一下 dateFormat 或者传入格式，增加 toDateWithTime 方法的目的是便于直观调用

2. 本来想增加一个 toStrWithTime(Date date) 但是觉得太累赘了,于是作罢

3. 测试过都可以正常使用

4. 如果想到更直观的实现方式再来更新

**更新 PropKit get方法 **
如果是String 类型配置属性且不为空则 trim() 一下