### PR TITLE
修复部分PostgreSQL版本中java.sql.Date与java.sql.Timestamp的歧义问题

### DIFF
--- a/src/main/java/com/jfinal/plugin/activerecord/dialect/PostgreSqlDialect.java
+++ b/src/main/java/com/jfinal/plugin/activerecord/dialect/PostgreSqlDialect.java
@@ -16,6 +16,8 @@
 
 package com.jfinal.plugin.activerecord.dialect;
 
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -191,7 +193,33 @@ public class PostgreSqlDialect extends Dialect {
 			paras.add(ids[i]);
 		}
 	}
-	
+
+	public void fillStatement(PreparedStatement pst, List<Object> paras) throws SQLException {
+		for (int i=0, size=paras.size(); i<size; i++) {
+			Object value = paras.get(i);
+			if (value instanceof java.sql.Date) {
+				pst.setDate(i + 1, (java.sql.Date)value);
+			} else if (value instanceof java.sql.Timestamp) {
+				pst.setTimestamp(i + 1, (java.sql.Timestamp)value);
+			} else {
+				pst.setObject(i + 1, value);
+			}
+		}
+	}
+
+	public void fillStatement(PreparedStatement pst, Object... paras) throws SQLException {
+		for (int i=0; i<paras.length; i++) {
+			Object value = paras[i];
+			if (value instanceof java.sql.Date) {
+				pst.setDate(i + 1, (java.sql.Date)value);
+			} else if (value instanceof java.sql.Timestamp) {
+				pst.setTimestamp(i + 1, (java.sql.Timestamp)value);
+			} else {
+				pst.setObject(i + 1, value);
+			}
+		}
+	}
+
 	public String forPaginate(int pageNumber, int pageSize, String select, String sqlExceptSelect) {
 		int offset = pageSize * (pageNumber - 1);
 		StringBuilder ret = new StringBuilder();


### PR DESCRIPTION
在Centos7.0中使用PostgreSQL9.6对时间进行保存时会产生歧义引起的异常，需要和Oracle数据库一样使用instanceof进行类型判断区分来解决此问题