### PR TITLE
特性加强：为JFinal增加多资源目录支持，支持资源文件与项目分离，加快编译打包速度，提升工作效率

### DIFF
--- a/src/main/java/com/jfinal/server/JettyServer.java
+++ b/src/main/java/com/jfinal/server/JettyServer.java
@@ -25,6 +25,7 @@ import org.eclipse.jetty.server.SessionManager;
 import org.eclipse.jetty.server.nio.SelectChannelConnector;
 import org.eclipse.jetty.server.session.HashSessionManager;
 import org.eclipse.jetty.server.session.SessionHandler;
+import org.eclipse.jetty.util.resource.ResourceCollection;
 import org.eclipse.jetty.webapp.WebAppContext;
 import com.jfinal.core.Const;
 import com.jfinal.kit.FileKit;
@@ -37,7 +38,6 @@ import com.jfinal.kit.StrKit;
  * Jetty version 8.1.8
  */
 class JettyServer implements IServer {
-	
 	private String webAppDir;
 	private int port;
 	private String context;
@@ -97,7 +97,9 @@ class JettyServer implements IServer {
 		webApp = new WebAppContext();
 		webApp.setThrowUnavailableOnStartupException(true);	// 在启动过程中允许抛出异常终止启动并退出 JVM
 		webApp.setContextPath(context);
-		webApp.setResourceBase(webAppDir);	// webApp.setWar(webAppDir);
+		ResourceCollection resources = new ResourceCollection();
+		resources.setResourcesAsCSV(webAppDir);
+		webApp.setBaseResource(resources);	// webApp.setWar(webAppDir);
 		webApp.setInitParameter("org.eclipse.jetty.servlet.Default.dirAllowed", "false");
 		webApp.setInitParameter("org.eclipse.jetty.servlet.Default.useFileMappedBuffer", "false");	// webApp.setInitParams(Collections.singletonMap("org.mortbay.jetty.servlet.Default.useFileMappedBuffer", "false"));
 		persistSession(webApp);

--- a/src/main/java/com/jfinal/server/JettyServerForIDEA.java
+++ b/src/main/java/com/jfinal/server/JettyServerForIDEA.java
@@ -25,6 +25,7 @@ import org.eclipse.jetty.server.SessionManager;
 import org.eclipse.jetty.server.nio.SelectChannelConnector;
 import org.eclipse.jetty.server.session.HashSessionManager;
 import org.eclipse.jetty.server.session.SessionHandler;
+import org.eclipse.jetty.util.resource.ResourceCollection;
 import org.eclipse.jetty.webapp.WebAppContext;
 import com.jfinal.core.Const;
 import com.jfinal.kit.FileKit;
@@ -39,7 +40,6 @@ import com.jfinal.kit.StrKit;
  *      插件支持列为完全的热加载
  */
 public class JettyServerForIDEA implements IServer {
-	
 	private String webAppDir;
 	private int port;
 	private String context;
@@ -99,7 +99,9 @@ public class JettyServerForIDEA implements IServer {
 		webApp = new WebAppContext();
 		webApp.setThrowUnavailableOnStartupException(true);	// 在启动过程中允许抛出异常终止启动并退出 JVM
 		webApp.setContextPath(context);
-		webApp.setResourceBase(webAppDir);	// webApp.setWar(webAppDir);
+		ResourceCollection resources = new ResourceCollection();
+		resources.setResourcesAsCSV(webAppDir);
+		webApp.setBaseResource(resources);	// webApp.setWar(webAppDir);
 		webApp.setInitParameter("org.eclipse.jetty.servlet.Default.dirAllowed", "false");
 		webApp.setInitParameter("org.eclipse.jetty.servlet.Default.useFileMappedBuffer", "false");	// webApp.setInitParams(Collections.singletonMap("org.mortbay.jetty.servlet.Default.useFileMappedBuffer", "false"));
 		persistSession(webApp);


### PR DESCRIPTION
特性加强：
1. 为 JettyServer 及 JettyServerForIDEA 增加 ResourceCollection 使 JFinal.start() 时支持多资源目录
解决打war包时大型（GB级）静态资源,打包时间超长，war 包巨大，部署上传时间超长问题，使得war应用与资源文件分离，
提升工作效率，简化开发阶复杂度，示例如下：

JFinal.start("src/main/webapp,/other/large/static-resource1,/other/large/static-resource2", 8080, "/");

webAppDir使用逗号分隔多个资源目录，假设

src/main/webapp/index.html
/other/large/static-resource1/static/index2.html
/other/large/static-resource1/static/index3.html

JFinal.start后，访问如下：

http://localhost:8080/index.html
http://localhost:8080/static/index1.html
http://localhost:8080/static/index2.html