### PR TITLE
[jfinal-29]change default log framework to slf4j

### DIFF
--- a/src/main/java/com/jfinal/log/Log.java
+++ b/src/main/java/com/jfinal/log/Log.java
@@ -35,8 +35,8 @@ public abstract class Log {
 	static void init() {
 		if (defaultLogFactory == null) {
 			try {
-				Class.forName("org.apache.log4j.Logger");
-				Class<?> log4jLogFactoryClass = Class.forName("com.jfinal.log.Log4jLogFactory");
+				Class.forName("org.slf4j.Logger");
+				Class<?> log4jLogFactoryClass = Class.forName("com.jfinal.log.Slf4jLogFactory");
 				defaultLogFactory = (ILogFactory)log4jLogFactoryClass.newInstance();	// return new Log4jLogFactory();
 			} catch (Exception e) {
 				defaultLogFactory = new JdkLogFactory();

--- a/src/main/java/com/jfinal/log/Slf4jLogFactory.java
+++ b/src/main/java/com/jfinal/log/Slf4jLogFactory.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2011-2019, James Zhan 詹波 (jfinal@126.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jfinal.log;
+
+
+public class Slf4jLogFactory implements ILogFactory {
+	@Override
+	public Log getLog(Class<?> clazz) {
+		return new Slf4jLogger(clazz);
+	}
+
+
+	@Override
+	public Log getLog(String name) {
+		return new Slf4jLogger(name);
+	}
+}

--- a/src/main/java/com/jfinal/log/Slf4jLogger.java
+++ b/src/main/java/com/jfinal/log/Slf4jLogger.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2011-2019, James Zhan 詹波 (jfinal@126.com).
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jfinal.log;
+
+
+public class Slf4jLogger extends Log {
+
+    private org.slf4j.Logger log;
+
+
+    Slf4jLogger(Class<?> clazz) {
+        log = org.slf4j.LoggerFactory.getLogger(clazz);
+    }
+
+
+    Slf4jLogger(String name) {
+        log = org.slf4j.LoggerFactory.getLogger(name);
+    }
+
+
+    // (marker, this, level, msg,params, t);注意参数顺序
+    @Override
+    public void info(String message) {
+        log.info(message);
+    }
+
+
+    @Override
+    public void info(String message, Throwable t) {
+        log.info(message, t);
+    }
+
+
+    @Override
+    public void debug(String message) {
+        log.debug(message);
+    }
+
+
+    @Override
+    public void debug(String message, Throwable t) {
+        log.debug(message, t);
+    }
+
+
+    @Override
+    public void warn(String message) {
+        log.warn(message);
+    }
+
+
+    @Override
+    public void warn(String message, Throwable t) {
+        log.warn(message, t);
+    }
+
+
+    @Override
+    public void error(String message) {
+        log.error(message);
+    }
+
+
+    @Override
+    public void error(String message, Throwable t) {
+        log.error(message, t);
+    }
+
+
+    @Override
+    public void fatal(String message) {
+        log.error(message);
+    }
+
+
+    @Override
+    public void fatal(String message, Throwable t) {
+        log.error(message, t);
+    }
+
+
+    @Override
+    public boolean isDebugEnabled() {
+        return log.isDebugEnabled();
+    }
+
+
+    @Override
+    public boolean isInfoEnabled() {
+        return log.isInfoEnabled();
+    }
+
+
+    @Override
+    public boolean isWarnEnabled() {
+        return log.isWarnEnabled();
+    }
+
+
+    @Override
+    public boolean isErrorEnabled() {
+        return log.isErrorEnabled();
+    }
+
+
+    @Override
+    public boolean isFatalEnabled() {
+        return log.isErrorEnabled();
+    }
+}


### PR DESCRIPTION
**What is the purpose of the change**
解决了 "建议将log4j更换为logback吧，更加灵活的log日志使用 #29(https://github.com/jfinal/jfinal/issues/29)"

**Brief changelog**
将默认的日志框架修改为了slf4j,日志框架具体实现可由用户选择
