### PR TITLE
[jfinal-138] set StringGetter defaultValue to empty string

### DIFF
--- a/src/main/java/com/jfinal/core/paragetter/ParaProcessorBuilder.java
+++ b/src/main/java/com/jfinal/core/paragetter/ParaProcessorBuilder.java
@@ -42,7 +42,7 @@ public class ParaProcessorBuilder {
 		regist(java.lang.Float.class, FloatGetter.class, null);
 		regist(java.lang.Double.class, DoubleGetter.class, null);
 		regist(java.lang.Boolean.class, BooleanGetter.class, null);
-		regist(java.lang.String.class, StringGetter.class, null);
+		regist(java.lang.String.class, StringGetter.class, "");
 		regist(java.util.Date.class, DateGetter.class, null);
 		regist(java.sql.Date.class, SqlDateGetter.class, null);
 		regist(java.sql.Time.class, TimeGetter.class, null);


### PR DESCRIPTION
**What is the purpose of the change**
解决了 "使用jfinal-java8中的Para注解问题 [#138](https://github.com/jfinal/jfinal/issues/138)"

**Brief changelog**
StringGetter 的默认值是null,对于将string参数默认值设置为空字符串的情形,现有代码无法支持.对于非基本类型,应该尽量避免使用null,因此将StringGetter的默认值修改为空字符串
